### PR TITLE
Docs: Fixed url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lets Mithril work with Jest",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ArthurClemens/mithril-test.git"
+    "url": "https://github.com/ArthurClemens/mithril-jest.git"
   },
   "main": "dist/mithril-jest",
   "module": "dist/mithril-jest.mjs",


### PR DESCRIPTION
Homepage and repository links in https://www.npmjs.com/package/mithril-jest are broken because of a typo in url in `package.json`. Fixing that with this PR.